### PR TITLE
Fix rabbit bowl rotation

### DIFF
--- a/objects/254.txt
+++ b/objects/254.txt
@@ -1,7 +1,7 @@
 id=254
 Bowl of Rabbit
 containable=1
-containSize=2.000000,vertSlotRot=0.000000
+containSize=2.000000,vertSlotRot=-0.250000
 permanent=0,minPickupAge=3
 noFlip=0
 sideAccess=0

--- a/objects/255.txt
+++ b/objects/255.txt
@@ -1,7 +1,7 @@
 id=255
 Bowl of Minced Rabbit
 containable=1
-containSize=2.000000,vertSlotRot=0.000000
+containSize=2.000000,vertSlotRot=-0.250000
 permanent=0,minPickupAge=3
 noFlip=0
 sideAccess=0


### PR DESCRIPTION
Rabbit bowls currently sit sideways inside boxes and horsecarts, little edit to their rotation to fix that and make them match with the rest of the pie ingredients.

Before:
<img width="642" height="402" alt="image" src="https://github.com/user-attachments/assets/dc2164d5-c97f-455b-895d-4da538ad98c6" />

After:
<img width="623" height="401" alt="image" src="https://github.com/user-attachments/assets/2c07918b-0b63-4ee8-a322-84349f9ad463" />
